### PR TITLE
Fix Vercel build — exclude migration/ from app type-check

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,6 +49,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "migration"
   ]
 }


### PR DESCRIPTION
The production build (`pnpm run vercel-build` → `next build`) failed at the TypeScript step because the root `tsconfig.json` includes `**/*.ts`, pulling the standalone `migration/` script project (its own `tsconfig.json` + `node_modules`) into the Next app's type-check. On Vercel that project's deps aren't installed, so it errors and breaks the build.

Fix: add `migration` to `tsconfig.json` `exclude`. App code is unaffected; `next build` now passes locally with all routes compiling cleanly.